### PR TITLE
make the unique of extensions and packages less prone to errors

### DIFF
--- a/lib/php/general.sh
+++ b/lib/php/general.sh
@@ -173,7 +173,14 @@ install_runtime_packages() {
   # unique the list
   declare -a install_pkgs
   for i in "${pkgs[@]}"; do
-    if [[ ! ${install_pkgs[@]} =~ $i ]]; then
+    add="true"
+    for j in "${install_pkgs[@]}"; do
+      if [[ "$i" = "$j" ]]; then
+        add="false"
+        break;
+      fi
+    done
+    if [[ "$add" = "true" ]]; then
       install_pkgs+=(${i})
     fi
   done 

--- a/lib/php/php/general.sh
+++ b/lib/php/php/general.sh
@@ -278,7 +278,14 @@ extensions() {
       value=PL_config_extensions_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             extensions_list+=(${!value})
           fi
         else
@@ -304,7 +311,14 @@ zend_extensions() {
       value=PL_config_zend_extensions_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${zend_extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${zend_extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             zend_extensions_list+=(${!value})
           fi
         else
@@ -331,7 +345,14 @@ dev_extensions() {
       value=PL_config_extensions_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             extensions_list+=(${!value})
           fi
         else
@@ -346,7 +367,14 @@ dev_extensions() {
       value=PL_config_dev_extensions_add_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             extensions_list+=(${!value})
           fi
         else
@@ -381,7 +409,14 @@ dev_zend_extensions() {
       value=PL_config_zend_extensions_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${zend_extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${zend_extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             zend_extensions_list+=(${!value})
           fi
         else
@@ -396,7 +431,14 @@ dev_zend_extensions() {
       value=PL_config_dev_zend_extensions_add_${i}_value
       if [[ ${!type} = "string" ]]; then
         if [[ -f ${extension_dir}/${!value}.so ]]; then
-          if [[ ! ${zend_extensions_list[@]} =~ ${!value} ]]; then
+          add="true"
+          for j in "${zend_extensions_list[@]}"; do
+            if [[ "$j" = "${!value}" ]]; then
+              add="false"
+              break;
+            fi
+          done
+          if [[ "$add" = "true" ]]; then
             zend_extensions_list+=(${!value})
           fi
         else

--- a/test/tests/integration/unique-extensions.bats
+++ b/test/tests/integration/unique-extensions.bats
@@ -12,7 +12,7 @@ payload() {
   "cache_dir": "/tmp/cache",
   "etc_dir": "/data/etc",
   "env_dir": "/data/etc/env.d",
-  "config": {"extensions": ["json","json","json","json","json"],"zend_extensions":["xcache","xcache"],"dev_extensions":{"add":["geoip", "geoip"],"rm":["mongo"]},"dev_zend_extensions":{"add":["xdebug", "xdebug"],"rm":["xcache"]}}
+  "config": {"extensions": ["json","json","json","json","json","xmlwriter","xml"],"zend_extensions":["xcache","xcache"],"dev_extensions":{"add":["geoip", "geoip"],"rm":["mongo"]},"dev_zend_extensions":{"add":["xdebug", "xdebug"],"rm":["xcache"]}}
 }
 END
 }
@@ -60,18 +60,26 @@ setup() {
   echo "$output"
   echo "$(grep -c json.so /data/etc/php/prod_php.ini)"
   echo "$(grep -c xcache.so /data/etc/php/prod_php.ini)"
+  echo "$(grep -c xml.so /data/etc/php/prod_php.ini)"
+  echo "$(grep -c xmlwriter.so /data/etc/php/prod_php.ini)"
   echo "$(grep -c json.so /data/etc/php/dev_php.ini)"
   echo "$(grep -c xcache.so /data/etc/php/dev_php.ini)"
   echo "$(grep -c geoip.so /data/etc/php/dev_php.ini)"
   echo "$(grep -c xdebug.so /data/etc/php/dev_php.ini)"
+  echo "$(grep -c xml.so /data/etc/php/dev_php.ini)"
+  echo "$(grep -c xmlwriter.so /data/etc/php/dev_php.ini)"
 
   [ "$status" -eq 0 ]
   [ "$(grep -c json.so /data/etc/php/prod_php.ini)" = "1" ]
   [ "$(grep -c xcache.so /data/etc/php/prod_php.ini)" = "1" ]
+  [ "$(grep -c xml.so /data/etc/php/prod_php.ini)" = "1" ]
+  [ "$(grep -c xmlwriter.so /data/etc/php/prod_php.ini)" = "1" ]
   [ "$(grep -c json.so /data/etc/php/dev_php.ini)" = "1" ]
   [ "$(grep -c xcache.so /data/etc/php/dev_php.ini)" = "0" ]
   [ "$(grep -c geoip.so /data/etc/php/dev_php.ini)" = "1" ]
   [ "$(grep -c xdebug.so /data/etc/php/dev_php.ini)" = "1" ]
+  [ "$(grep -c xml.so /data/etc/php/dev_php.ini)" = "1" ]
+  [ "$(grep -c xmlwriter.so /data/etc/php/dev_php.ini)" = "1" ]
 }
 
 @test "compile" {


### PR DESCRIPTION
There was an issue of improper matching with extensions. For example, the extension xml was matching against xmlwriter, and being filtered out.