### PR TITLE
Anchor Cache Directory

### DIFF
--- a/bin/boxfile
+++ b/bin/boxfile
@@ -14,7 +14,7 @@ nos_init "$@"
 cat <<-END
 run.config:
   cache_dirs:
-    - vendor
+    - /vendor
   extra_path_dirs:
     - ${HOME}/.composer/vendor/bin
     - $(nos_code_dir)/vendor/bin


### PR DESCRIPTION
This should prevent the automatic addition of `cache_dirs` to the `.nanoignore` list from *also* preventing other files/folders named `vendor` from being deployed.