### PR TITLE
Fix PHP-FPM docroot setting for Apache 2.4

### DIFF
--- a/templates/apache/apache.conf.mustache
+++ b/templates/apache/apache.conf.mustache
@@ -9,32 +9,27 @@ KeepAlive On
 MaxKeepAliveRequests 100
 KeepAliveTimeout 15
 
-{{^apache24}}
 StartServers          1
+{{^apache24}}
 MinSpareServers       1
 MaxSpareServers       {{max_spares}}
 MaxClients            {{max_clients}}
 MaxRequestsPerChild   {{max_requests_per_child}}
-ServerLimit           {{server_limit}}
 {{/apache24}}
 {{#apache24}}
 {{#mod_php}}
-StartServers           1
 MinSpareServers        1
 MaxSpareServers        {{max_spares}}
 MaxClients             {{max_clients}}
-MaxConnectionsPerChild {{max_requests_per_child}}
-ServerLimit            {{server_limit}}
 {{/mod_php}}
 {{#fastcgi}}
-StartServers           1
 MinSpareThreads        1
 MaxSpareThreads        {{max_spares}}
 MaxRequestWorkers      {{max_clients}}
-MaxConnectionsPerChild {{max_requests_per_child}}
-ServerLimit            {{server_limit}}
 {{/fastcgi}}
+MaxConnectionsPerChild {{max_requests_per_child}}
 {{/apache24}}
+ServerLimit            {{server_limit}}
 
 ServerName localhost
 Listen 0.0.0.0:8080
@@ -89,7 +84,7 @@ LoadModule {{.}}_module lib/httpd/mod_{{.}}.so
 UseCanonicalName Off
 HostnameLookups Off
 DocumentRoot "{{code_dir}}{{document_root}}"
-DirectoryIndex {{directory_index}} {{default_gateway}} 
+DirectoryIndex {{directory_index}} {{default_gateway}}
 AccessFileName .htaccess
 TypesConfig {{etc_dir}}/httpd/mime.types
 DefaultType text/plain
@@ -154,7 +149,7 @@ AddHandler php-fastcgi .php
 Action php-fastcgi /cgi-bin/php-cgi
 {{/apache24}}
 {{#apache24}}
-ProxyPassMatch "^/(.*\.php(/.*)?)$" "unix:{{data_dir}}/var/tmp/php.sock|fcgi://localhost{{code_dir}}"
+ProxyPassMatch "^/(.*\.php(/.*)?)$" "unix:{{data_dir}}/var/tmp/php.sock|fcgi://localhost{{code_dir}}{{document_root}}"
 {{/apache24}}
 {{/fastcgi}}
 


### PR DESCRIPTION
When using Apache 2.4, the document root is passed to the FPM process when connecting to the socket itself, rather than with each file request.  Without passing this value properly, apps with a docroot that isn't the project root (many frameworks fall under this category) will fail to load any files.

(Also performed some minor cleanup involving reduction of duplication...)