### PR TITLE
the json shouldnt put quotes around the value of the apache access lo…

### DIFF
--- a/lib/php/apache.sh
+++ b/lib/php/apache.sh
@@ -52,7 +52,7 @@ apache_conf_payload() {
   "etc_dir": "$(nos_etc_dir)",
   "static_expire": "$(apache_static_expire)",
   "log_level": "$(apache_log_level)",
-  "access_log": "$(apache_access_log)",
+  "access_log": $(apache_access_log),
   "apache24": $(apache24),
   "php7": $(php7)
 }


### PR DESCRIPTION
…g, that makes it a string rather than a boolean