### PR TITLE
Added access_compat to apache module list

### DIFF
--- a/doc/apache-modules.md
+++ b/doc/apache-modules.md
@@ -14,6 +14,7 @@ The apache modules listed below are available to the Nanobox PHP engine.
 - setenvif
 
 ## Optional Modules
+- access_compat
 - asis
 - auth_basic
 - auth_digest


### PR DESCRIPTION
The module does work and is required to run Prestashop (tested 1.6, 1.7)