### PR TITLE
Update apache_max_clients default

### DIFF
--- a/lib/php/apache.sh
+++ b/lib/php/apache.sh
@@ -79,7 +79,7 @@ apache_max_spares() {
 
 apache_max_clients() {
   # boxfile apache_max_clients
-  apache_max_clients=$(nos_validate "$(nos_payload config_apache_max_clients)" "integer" "128")
+  apache_max_clients=$(nos_validate "$(nos_payload config_apache_max_clients)" "integer" "125")
   echo "$apache_max_clients"
 }
 


### PR DESCRIPTION
`apache_max_clients` config is used for the `MaxRequestWorkers` setting. With a value of `128`, Apache will show a Warning:
`WARNING: MaxRequestWorkers of 128 is not an integer multiple of ThreadsPerChild of 25, decreasing to nearest multiple 125, for a maximum of 5 servers.`

Setting this config to 125 in the boxfile.yml removes the warning. Having 125 as the default value should remove the warning without additional effort from the user.