### PR TITLE
Don't prefer source for Composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The composer install command can be customized during the build process using a 
 run.config:
   engine: php
   engine.config:
-    composer_install: "composer install --no-interaction --prefer-source"
+    composer_install: "composer install --no-interaction"
 ```
 
 ## Basic Configuration

--- a/bin/boxfile
+++ b/bin/boxfile
@@ -13,8 +13,6 @@ nos_init "$@"
 
 cat <<-END
 run.config:
-  cache_dirs:
-    - /vendor
   extra_path_dirs:
     - ${HOME}/.composer/vendor/bin
     - $(nos_code_dir)/vendor/bin

--- a/doc/advanced-php-config.md
+++ b/doc/advanced-php-config.md
@@ -52,7 +52,7 @@ run.config:
     iconv_internal_encoding: 'UTF-8'
     
     # Composer Settings
-    composer_install: 'composer install --no-interaction --prefer-source'
+    composer_install: 'composer install --no-interaction'
 
     # Apache Settings
     apache_version: 2.2
@@ -588,18 +588,18 @@ run.config:
 ### Composer Settings
 The following settings allow you to customize how [Composer](https://getcomposer.org/) is used in your application.
 
-[composer_install](#composer_install)  
+[composer_install](#composer_install)
 
 ---
 
-#### composer_install 
+#### composer_install
 Customize the `composer install` command that is run in your app's build process.
 
 ```
 run.config:
   engine: php
   engine.config:
-    composer_install: 'composer install --no-interaction --prefer-source'
+    composer_install: 'composer install --no-interaction'
 ```
 
 ---

--- a/lib/php/composer.sh
+++ b/lib/php/composer.sh
@@ -14,7 +14,7 @@ composer_required_extensions() {
 
 composer_install_command() {
   # boxfile composer_install
-  composer_install_command=$(nos_validate "$(nos_payload config_composer_install)" "string" "composer install --no-interaction --prefer-source")
+  composer_install_command=$(nos_validate "$(nos_payload config_composer_install)" "string" "composer install --no-interaction")
   echo "$composer_install_command"
 }
 


### PR DESCRIPTION
There is no point in preferring slow Git clones over quick dist archive downloads.

Also see #19 