### PR TITLE
Add support for passing the docroot at start time

### DIFF
--- a/lib/php/apache.sh
+++ b/lib/php/apache.sh
@@ -2,10 +2,10 @@
 # vim: ts=2 sw=2 ft=bash noet
 
 generate_apache_conf() {
-  
+
   # Report back to the user
   report_apache_settings
-  
+
   nos_template \
     "apache/apache.conf.mustache" \
     "$(nos_etc_dir)/httpd/httpd.conf" \
@@ -16,11 +16,11 @@ report_apache_settings() {
   if [[ "$(apache_mod_php)" = "true" ]]; then
     nos_print_bullet_sub "Enabling mod_php"
   fi
-  
+
   if [[ "$(php_fpm_use_fastcgi)" = "true" ]]; then
     nos_print_bullet_sub "Enabling FastCGI"
   fi
-  
+
   nos_print_bullet_sub "Max spare servers: $(apache_max_spares)"
   nos_print_bullet_sub "Max clients: $(apache_max_clients)"
   nos_print_bullet_sub "Max requests per child: $(apache_max_requests_per_child)"
@@ -164,7 +164,7 @@ apache_access_log() {
 apache_packages() {
   apv=$(apache_version)
   pkgs=("apache-${apv}" "ap${apv//[.-]/}-cloudflare" "ap${apv//[.-]/}-xsendfile")
-  
+
   if [[ "$(php_fpm_use_fastcgi)" = "true" ]]; then
     if [[ "${apv}" = "2.2" ]]; then
       pkgs+=("ap${apv//[.-]/}-fastcgi")
@@ -172,7 +172,7 @@ apache_packages() {
   else
     pkgs+=("ap${apv//[.-]/}-$(condensed_runtime)")
   fi
-  
+
   echo "${pkgs[@]}"
 }
 
@@ -187,7 +187,10 @@ generate_apache_php_fpm_script() {
 apache_php_fpm_script_payload() {
   cat <<-END
 {
-  "data_dir": "$(nos_data_dir)"
+  "code_dir": "$(nos_code_dir)",
+  "data_dir": "$(nos_data_dir)",
+  "document_root": "$(apache_document_root)",
+  "apache24": $(apache24),
 }
 END
 }
@@ -203,8 +206,10 @@ generate_apache_mod_php_script() {
 apache_mod_php_script_payload() {
   cat <<-END
 {
+  "code_dir": "$(nos_code_dir)",
   "data_dir": "$(nos_data_dir)",
-  "etc_dir": "$(nos_etc_dir)"
+  "etc_dir": "$(nos_etc_dir)",
+  "document_root": "$(apache_document_root)"
 }
 END
 }

--- a/lib/php/nginx.sh
+++ b/lib/php/nginx.sh
@@ -2,10 +2,10 @@
 # vim: ts=2 sw=2 ft=bash noet
 
 generate_nginx_conf() {
-  
+
   # Report back to the user
   report_nginx_settings
-  
+
   nos_template \
   "nginx/nginx.conf.mustache" \
   "$(nos_etc_dir)/nginx/nginx.conf" \
@@ -21,8 +21,8 @@ report_nginx_settings() {
 nginx_conf_payload() {
   cat <<-END
 {
-  "data_dir": "$(nos_data_dir)",
   "code_dir": "$(nos_code_dir)",
+  "data_dir": "$(nos_data_dir)",
   "document_root": "$(nginx_document_root)",
   "directory_index": "$(nginx_directory_index)",
   "default_gateway": "$(nginx_default_gateway)"
@@ -36,7 +36,7 @@ nginx_document_root() {
 
   if [[ ${document_root:0:1} = '/' ]]; then
     echo $document_root
-  else 
+  else
     echo /$document_root
   fi
 }
@@ -72,7 +72,10 @@ generate_nginx_script() {
 nginx_script_payload() {
   cat <<-END
 {
-  "data_dir": "$(nos_data_dir)"
+  "code_dir": "$(nos_code_dir)",
+  "data_dir": "$(nos_data_dir)",
+  "etc_dir": "$(nos_etc_dir)",
+  "document_root": "$(nginx_document_root)",
 }
 END
 }

--- a/templates/apache/apache.conf.mustache
+++ b/templates/apache/apache.conf.mustache
@@ -104,7 +104,7 @@ AddOutputFilterByType DEFLATE text/plain text/html text/xml text/css application
 #Header unset ETag
 FileETag Mtime Size
 
-<Directory />
+<Directory {{code_dir}}>
     Options Indexes FollowSymLinks
     AllowOverride All
     DirectoryIndex {{ directory_index }} {{ default_gateway }}
@@ -155,16 +155,7 @@ ProxyPassMatch "^/(.*\.php(/.*)?)$" "unix:{{data_dir}}/var/tmp/php.sock|fcgi://l
 {{/apache24}}
 {{/fastcgi}}
 
-#############################################
-# VirtualHost Configuration                 #
-#############################################
-
-<VirtualHost *:8080>
-    DocumentRoot "{{code_dir}}{{document_root}}"
-    ServerName localhost
-    DirectoryIndex {{directory_index}} {{default_gateway}}
-    UnsetEnv USER HOME
-    SetEnvifNoCase X-Forwarded-Proto "https" HTTPS=on
-    RewriteEngine on
-    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
-</VirtualHost>
+UnsetEnv USER HOME
+SetEnvifNoCase X-Forwarded-Proto "https" HTTPS=on
+RewriteEngine on
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]

--- a/templates/bin/php-server.mustache
+++ b/templates/bin/php-server.mustache
@@ -13,19 +13,27 @@ function ctrl_c() {
   fi
 }
 
+document_root="${1:-{{document_root}}}"
+document_root="/${document_root##/}"
+
 {{#apache}}
 start_apache() {
-  start-apache &
+  start-apache ${document_root} &
 }
 {{/apache}}
 {{#nginx}}
 start_nginx() {
-  start-nginx &
+  start-nginx ${document_root} &
 }
 {{/nginx}}
 {{^mod_php}}
 start_php() {
+  {{^builtin}}
   start-php &
+  {{/builtin}}
+  {{#builtin}}
+  start-php ${document_root} &
+  {{/builtin}}
 }
 {{/mod_php}}
 
@@ -80,7 +88,7 @@ start_logging() {
   {{/builtin}}
   logs+=({{data_dir}}/var/log/php/php_error.log)
   {{#fpm}}
-  logs+=({{data_dir}}/var/log/php/php_fpm.log)
+  logs+=({{data_dir}}/var/log/php/php-fpm.log)
   {{/fpm}}
   {{#apache}}
   # apache logs

--- a/templates/bin/start-apache-mod-php.mustache
+++ b/templates/bin/start-apache-mod-php.mustache
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+document_root="${1:-{{document_root}}}"
+document_root="/${document_root##/}"
+
 if [[ "$APP_NAME" = "dev" ]]; then
   cp {{etc_dir}}/php/dev_php.ini {{etc_dir}}/php/php.ini
   ln -sTf {{etc_dir}}/php.dev.d {{etc_dir}}/php.d
@@ -8,4 +11,4 @@ else
   ln -sTf {{etc_dir}}/php.prod.d {{etc_dir}}/php.d
 fi
 
-exec {{data_dir}}/sbin/httpd -DNO_DETACH
+exec {{data_dir}}/sbin/httpd -DNO_DETACH -c "DocumentRoot {{code_dir}}${document_root}"

--- a/templates/bin/start-apache-php-fpm.mustache
+++ b/templates/bin/start-apache-php-fpm.mustache
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-exec {{data_dir}}/sbin/httpd -DNO_DETACH
+document_root="${1:-{{document_root}}}"
+document_root="/${document_root##/}"
+
+exec {{data_dir}}/sbin/httpd -DNO_DETACH -c "DocumentRoot {{code_dir}}${document_root}"{{#apache24}} \
+     -C "ProxyPassMatch \"^/(.*\.php(/.*)?)$\" \"unix:{{data_dir}}/var/tmp/php.sock|fcgi://localhost{{code_dir}}${document_root}\""{{/apache24}}

--- a/templates/bin/start-nginx-php-fpm.mustache
+++ b/templates/bin/start-nginx-php-fpm.mustache
@@ -1,3 +1,16 @@
 #!/bin/bash
 
-exec {{data_dir}}/sbin/nginx
+document_root="${1:-{{document_root}}}"
+document_root="/${document_root##/}"
+
+if [ "${document_root}" != "{{document_root}}" ]
+then
+  TMPFILE=$(mktemp -q -t) && {
+    # Safe to use $TMPFILE in this block
+    cp {{etc_dir}}/nginx/nginx.conf "${TMPFILE}"
+    sed -i "s:root \+{{code_dir}}{{document_root}}:root {{code_dir}}${document_root}:" "${TMPFILE}"
+    exec {{data_dir}}/sbin/nginx -c "${TMPFILE}"
+  }
+else
+  exec {{data_dir}}/sbin/nginx
+fi

--- a/templates/bin/start-php-builtin.mustache
+++ b/templates/bin/start-php-builtin.mustache
@@ -8,4 +8,7 @@ else
   ln -sTf {{etc_dir}}/php.prod.d {{etc_dir}}/php.d
 fi
 
-exec {{data_dir}}/bin/php -S 0.0.0.0:8080 -c {{etc_dir}}/php/php.ini -t {{code_dir}}{{document_root}}/
+document_root="${1:-{{document_root}}}"
+document_root="/${document_root##/}"
+
+exec {{data_dir}}/bin/php -S 0.0.0.0:8080 -c {{etc_dir}}/php/php.ini -t {{code_dir}}${document_root}/

--- a/templates/boxfile.mustache
+++ b/templates/boxfile.mustache
@@ -14,7 +14,7 @@ web.main:
     apache[error]: {{data_dir}}/var/log/apache/error.log
     php[error]: {{data_dir}}/var/log/php/php_error.log
 {{#fpm}}
-    php[fpm]: {{data_dir}}/var/log/php/php_fpm.log
+    php[fpm]: {{data_dir}}/var/log/php/php-fpm.log
 {{/fpm}}
 {{/apache}}
 {{#nginx}}
@@ -25,7 +25,7 @@ web.main:
     nginx[access]: {{data_dir}}/var/log/nginx/access.log
     nginx[error]: {{data_dir}}/var/log/nginx/error.log
     php[error]: {{data_dir}}/var/log/php/php_error.log
-    php[fpm]: {{data_dir}}/var/log/php/php_fpm.log
+    php[fpm]: {{data_dir}}/var/log/php/php-fpm.log
 {{/nginx}}
 {{#builtin}}
   start: {{data_dir}}/bin/start-php

--- a/test/apps/multi-docroot/api/api/index.php
+++ b/test/apps/multi-docroot/api/api/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the api/api directory";

--- a/test/apps/multi-docroot/api/index.php
+++ b/test/apps/multi-docroot/api/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the api directory";

--- a/test/apps/multi-docroot/api/wp/index.php
+++ b/test/apps/multi-docroot/api/wp/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the api/wp directory";

--- a/test/apps/multi-docroot/boxfile.apache-fpm.yml
+++ b/test/apps/multi-docroot/boxfile.apache-fpm.yml
@@ -1,0 +1,16 @@
+run.config:
+  engine: php
+
+web.wp:
+  start:
+    php: start-php
+    apache: start-apache wp
+  routes:
+    - /
+
+web.api:
+  start:
+    php: start-php
+    apache: start-apache api
+  routes:
+    - api:/

--- a/test/apps/multi-docroot/boxfile.apache-mod.yml
+++ b/test/apps/multi-docroot/boxfile.apache-mod.yml
@@ -1,0 +1,14 @@
+run.config:
+  engine: php
+
+web.wp:
+  start:
+    apache: start-apache wp
+  routes:
+    - /
+
+web.api:
+  start:
+    apache: start-apache api
+  routes:
+    - api:/

--- a/test/apps/multi-docroot/boxfile.builtin.yml
+++ b/test/apps/multi-docroot/boxfile.builtin.yml
@@ -1,0 +1,14 @@
+run.config:
+  engine: php
+
+web.wp:
+  start:
+    php: start-php wp
+  routes:
+    - /
+
+web.api:
+  start:
+    php: start-php api
+  routes:
+    - api:/

--- a/test/apps/multi-docroot/boxfile.nginx.yml
+++ b/test/apps/multi-docroot/boxfile.nginx.yml
@@ -1,0 +1,16 @@
+run.config:
+  engine: php
+
+web.wp:
+  start:
+    php: start-php
+    nginx: start-nginx wp
+  routes:
+    - /
+
+web.api:
+  start:
+    php: start-php
+    nginx: start-nginx api
+  routes:
+    - api:/

--- a/test/apps/multi-docroot/index.php
+++ b/test/apps/multi-docroot/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the {root} directory";

--- a/test/apps/multi-docroot/wp/api/index.php
+++ b/test/apps/multi-docroot/wp/api/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the wp/api directory";

--- a/test/apps/multi-docroot/wp/index.php
+++ b/test/apps/multi-docroot/wp/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the wp directory";

--- a/test/apps/multi-docroot/wp/wp/index.php
+++ b/test/apps/multi-docroot/wp/wp/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "This is the wp/wp directory";

--- a/test/tests/integration/multi-docroot-apache-2.2-fpm.bats
+++ b/test/tests/integration/multi-docroot-apache-2.2-fpm.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "apache_version": "2.2" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.apache-fpm,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}

--- a/test/tests/integration/multi-docroot-apache-2.2-mod_php.bats
+++ b/test/tests/integration/multi-docroot-apache-2.2-mod_php.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "apache_php_interpreter": "mod_php", "apache_version": "2.2" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.apache-mod,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}

--- a/test/tests/integration/multi-docroot-apache-2.4-fpm.bats
+++ b/test/tests/integration/multi-docroot-apache-2.4-fpm.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "apache_version": "2.4" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.apache-fpm,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}

--- a/test/tests/integration/multi-docroot-apache-2.4-mod_php.bats
+++ b/test/tests/integration/multi-docroot-apache-2.4-mod_php.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "apache_php_interpreter": "mod_php", "apache_version": "2.4" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.apache-mod,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}

--- a/test/tests/integration/multi-docroot-builtin.bats
+++ b/test/tests/integration/multi-docroot-builtin.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "webserver": "builtin" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.builtin,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}

--- a/test/tests/integration/multi-docroot-nginx.bats
+++ b/test/tests/integration/multi-docroot-nginx.bats
@@ -1,0 +1,129 @@
+# Integration test for a simple go app
+
+# source environment helpers
+. util/env.sh
+
+payload() {
+  cat <<-END
+{
+  "code_dir": "/tmp/code",
+  "data_dir": "/data",
+  "app_dir": "/tmp/app",
+  "cache_dir": "/tmp/cache",
+  "etc_dir": "/data/etc",
+  "env_dir": "/data/etc/env.d",
+  "config": { "runtime": "php-7.0", "extensions": ["amqp", "dom", "timezonedb"], "webserver": "nginx" }
+}
+END
+}
+
+setup() {
+  # cd into the engine bin dir
+  cd /engine/bin
+}
+
+@test "setup" {
+  # prepare environment (create directories etc)
+  prepare_environment
+
+  # prepare pkgsrc
+  run prepare_pkgsrc
+
+  # create the code_dir
+  mkdir -p /tmp/code
+
+  # copy the app into place
+  cp -ar /test/apps/multi-docroot/* /tmp/code
+  mv /tmp/code/boxfile{.nginx,}.yml
+  rm /tmp/code/boxfile.*.yml
+
+  run pwd
+
+  [ "$output" = "/engine/bin" ]
+}
+
+@test "boxfile" {
+  if [[ ! -f /engine/bin/boxfile ]]; then
+    skip "No boxfile script"
+  fi
+  run /engine/bin/boxfile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "build" {
+  if [[ ! -f /engine/bin/build ]]; then
+    skip "No build script"
+  fi
+  run /engine/bin/build "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "compile" {
+  if [[ ! -f /engine/bin/compile ]]; then
+    skip "No compile script"
+  fi
+  run /engine/bin/compile "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "cleanup" {
+  if [[ ! -f /engine/bin/cleanup ]]; then
+    skip "No cleanup script"
+  fi
+  run /engine/bin/cleanup "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "release" {
+  if [[ ! -f /engine/bin/release ]]; then
+    skip "No release script"
+  fi
+  run /engine/bin/release "$(payload)"
+
+  echo "$output"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "verify" {
+  # remove the code dir
+  rm -rf /tmp/code
+
+  # mv the app_dir to code_dir
+  mv /tmp/app /tmp/code
+
+  # cd into the app code_dir
+  cd /tmp/code
+
+  export TEST_VARIABLE=testing
+
+  # start php built-in server
+  # /data/bin/start-php &
+  php-server api &
+
+  # sleep a few seconds so the server can start
+  sleep 3
+
+  # curl the index
+  run curl -s 127.0.0.1:8080 2>/dev/null
+
+  # kill the server
+  # pkill php
+  pkill php-server
+
+  echo "$output"
+
+  [[ "$output" =~ "This is the api directory" ]]
+}


### PR DESCRIPTION
All runtime combinations now support passing in a path relative to `/app/` as an argument to their startup scripts. If present, it will replace the engine-level `document_root` setting. If absent, the engine's setting will be preserved instead.

Full testing is included in this PR.